### PR TITLE
Ichiyo: マスタデータからClaudeモデルを指定可能に

### DIFF
--- a/Common/Master/IchiyoSettingMaster.cs
+++ b/Common/Master/IchiyoSettingMaster.cs
@@ -57,4 +57,9 @@ public class IchiyoSettingMaster : MasterTable<string, Setting>
     /// context-window limitに達した時のメッセージ
     /// </summary>
     public string ContextLimitMessage => GetString(nameof(ContextLimitMessage));
+
+    /// <summary>
+    /// 使用するClaudeモデル名（haiku, sonnet, opus等）
+    /// </summary>
+    public string Model => GetString(nameof(Model));
 }

--- a/Events/Ichiyo/IchiyoChatPresenter.cs
+++ b/Events/Ichiyo/IchiyoChatPresenter.cs
@@ -198,6 +198,7 @@ public class IchiyoChatPresenter : DiscordMessagePresenterBase
         // モデル指定（未設定の場合はhaikuをデフォルトとする）
         const string DefaultModel = "haiku";
         var effectiveModel = string.IsNullOrEmpty(model) ? DefaultModel : model;
+        LogManager.Log($"[Ichiyo] Using model: {effectiveModel} (master: {model ?? "null"})");
 
         // コマンド引数を構築
         var arguments = new List<string>

--- a/Events/Ichiyo/IchiyoChatPresenter.cs
+++ b/Events/Ichiyo/IchiyoChatPresenter.cs
@@ -70,7 +70,7 @@ public class IchiyoChatPresenter : DiscordMessagePresenterBase
 
         try
         {
-            var result = await ExecuteClaudeCliAsync(formattedInput, settings.SystemPrompt, ResumeSessionId);
+            var result = await ExecuteClaudeCliAsync(formattedInput, settings.SystemPrompt, settings.Model, ResumeSessionId);
 
             if (result == null)
             {
@@ -193,8 +193,12 @@ public class IchiyoChatPresenter : DiscordMessagePresenterBase
     /// <summary>
     /// claude-cliを実行してレスポンスを取得する
     /// </summary>
-    private async Task<ClaudeCliResult?> ExecuteClaudeCliAsync(string userInput, string systemPrompt, string? resumeSessionId)
+    private async Task<ClaudeCliResult?> ExecuteClaudeCliAsync(string userInput, string systemPrompt, string model, string? resumeSessionId)
     {
+        // モデル指定（未設定の場合はhaikuをデフォルトとする）
+        const string DefaultModel = "haiku";
+        var effectiveModel = string.IsNullOrEmpty(model) ? DefaultModel : model;
+
         // コマンド引数を構築
         var arguments = new List<string>
         {
@@ -202,7 +206,7 @@ public class IchiyoChatPresenter : DiscordMessagePresenterBase
             "--tools", "WebFetch,WebSearch",
             "-p",
             "--output-format", "json",
-            "--model", "haiku",
+            "--model", effectiveModel,
         };
 
         if (!string.IsNullOrEmpty(resumeSessionId))


### PR DESCRIPTION
## Summary
- IchiyoSettingMasterに`Model`プロパティを追加
- Google Sheetsからモデル（haiku, sonnet, opus等）を動的に指定可能に
- 未設定時はhaikuをデフォルトとして使用（既存動作と互換）

## マージ後の作業
Google Sheets `ichiyo_setting`シートに以下を追加:

| key | value |
|-----|-------|
| Model | haiku |

有効な値: `haiku`, `sonnet`, `opus`

## Test plan
- [ ] マスタデータ未設定時にhaikuモデルで動作することを確認
- [ ] マスタデータ設定後に指定したモデルで動作することを確認
- [ ] Discordでボットにメンションし、レスポンスが返ることを確認